### PR TITLE
 replaymod replay and jsmacros Client.connect fix + fix builds (non-existing imports)

### DIFF
--- a/src/main/java/baritone/process/CustomGoalProcess.java
+++ b/src/main/java/baritone/process/CustomGoalProcess.java
@@ -23,7 +23,6 @@ import baritone.api.process.ICustomGoalProcess;
 import baritone.api.process.PathingCommand;
 import baritone.api.process.PathingCommandType;
 import baritone.utils.BaritoneProcessHelper;
-import baritone.utils.NotificationHelper;
 import baritone.utils.Trail;
 
 /**

--- a/src/main/java/baritone/process/ExploreProcess.java
+++ b/src/main/java/baritone/process/ExploreProcess.java
@@ -30,7 +30,6 @@ import baritone.api.process.PathingCommandType;
 import baritone.api.utils.MyChunkPos;
 import baritone.cache.CachedWorld;
 import baritone.utils.BaritoneProcessHelper;
-import baritone.utils.NotificationHelper;
 import baritone.utils.Trail;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/src/main/java/baritone/utils/BlockStateInterface.java
+++ b/src/main/java/baritone/utils/BlockStateInterface.java
@@ -43,7 +43,7 @@ public class BlockStateInterface {
 
     private final ClientChunkCache provider;
     private final WorldData worldData;
-    protected final BlockGetter world;
+    protected final Level world;
     public final BlockPos.MutableBlockPos isPassableBlockPos;
     public final BlockGetter access;
 
@@ -97,9 +97,9 @@ public class BlockStateInterface {
     }
 
     public BlockState get0(int x, int y, int z) { // Mickey resigned
-        y -= worldData.dimension.minY();
+        y -= world.dimensionType().minY();
         // Invalid vertical position
-        if (y < 0 || y >= worldData.dimension.height()) {
+        if (y < 0 || y >= world.dimensionType().height()) {
             return AIR;
         }
 


### PR DESCRIPTION
use world not worldData to prevent npe when in replaymod replay or when using Client.connect in jsmacros

and as a bonus, fix for building because of those missing imports